### PR TITLE
frdm-k22: changing AudioIF, IO, ADC and SAI

### DIFF
--- a/MonkeyJam/Sources/DSP/AudioIF.c
+++ b/MonkeyJam/Sources/DSP/AudioIF.c
@@ -134,7 +134,7 @@ uint32_t InitAudioIO( uint32_t    BusClockIn,
                        0, //Rx
                        1 //Enable both Channel
                       );
-   // sai_pinmux_init(0, 0);  //Port C
+    sai_pinmux_init(0, 0);  //Port C
     sai_stop_dbg_enable(0, 1, 0, 0);    //tx enabled in debug and stop
     sai_stop_dbg_enable(0, 0, 0, 0);    //RX enabled in debug and stop
     sai_watermark_config(0, //POrt 0
@@ -155,7 +155,11 @@ uint32_t InitAudioIO( uint32_t    BusClockIn,
     I2S0_TDR0 = 0;
     I2S0_TDR0 = 0;
     I2S0_TDR0 = 0;
-
+    PORTD_PCR3 = (PORT_PCR_MUX(1) | PORT_PCR_DSE_MASK);
+    GPIOD_PDDR |= 1<<3;
+    PORTD_PCR1 = (PORT_PCR_MUX(1) | PORT_PCR_DSE_MASK);
+    GPIOD_PDDR |= 1<<1;
+    GPIOD_PSOR = 0;
     sai_interrupt_enable(0, //Port
                          0 // Rx)
                         );

--- a/MonkeyJam/Sources/drivers/IO.c
+++ b/MonkeyJam/Sources/drivers/IO.c
@@ -11,44 +11,13 @@ void InitIO()
                  SIM_SCGC5_PORTC_MASK |
                  SIM_SCGC5_PORTD_MASK |
                  SIM_SCGC5_PORTE_MASK;
-      
-        
-    PORTC_PCR(4) = PORT_PCR_MUX(1)| PORT_PCR_PE_MASK | PORT_PCR_PS_MASK;  // Enable Pull-up;
-    PORTD_PCR(0) = PORT_PCR_MUX(1)| PORT_PCR_PE_MASK | PORT_PCR_PS_MASK;  // Enable Pull-up;;
-       
-    
-    
-    PORTC_PCR(3) = PORT_PCR_MUX(6);     //PTC3(ALT6), I2S0_TX_BCLK
-    PORTC_PCR(2) = PORT_PCR_MUX(6);     //PTC2(ALT6), I2S0_TX_FS	
-    PORTC_PCR(1) = PORT_PCR_MUX(6);     //PTC1(ALT6), I2S0_TXD0
-    
-    
-   PORTC_PCR(10) = PORT_PCR_MUX(4);    //PTC10(ALT4), I2S0_RX_FS
-   PORTC_PCR(5) = PORT_PCR_MUX(4);     //PTC5(ALT4), I2S0_RXD0
-                        
-   PORTC_PCR(6) = PORT_PCR_MUX(6);     //PTC6(ALT6), I2S0_MCLK
-   PORTC_PCR(8) = PORT_PCR_MUX(4);     //PTC6(ALT6), I2S0_MCLK
-  
-    //for K64 compatibility
-    PORTC_PCR(9) = PORT_PCR_MUX(1);    
-    GPIOC_PDDR &=~(1<<9);
-                     
-    PORTC_PCR(11) = PORT_PCR_MUX(1);   
-    GPIOC_PDDR &=~(1<<11);
-    
-    PORTD_PCR(7) = PORT_PCR_MUX(1);    
-     GPIOD_PDDR &=~(1<<7);
-     
-     PORTD_PCR(0) = PORT_PCR_MUX(1);    
-      GPIOD_PDDR &=~(1<<0);
-                       
-                      
     InitADC_12Bit();
     //This sets the SAI unit for 32MHz, 256x oversampling on the ADC/ Dacs
     InitAudioIO(50000000, 24000, 256);
+    PORTC_PCR(0) = PORT_PCR_MUX(1);
+    PORTC_PCR(4) = PORT_PCR_MUX(1)| PORT_PCR_PE_MASK | PORT_PCR_PS_MASK;  // Enable Pull-up;
+    PORTC_PCR(9) = PORT_PCR_MUX(1);
     
-
-        
     IO_DELTA_IS_INPUT;
     
 }
@@ -81,15 +50,15 @@ float ReadPOT(uint8_t Channel)
         {
             default:
             case POT_ALPHA:
-                Pot_Value =  (float)ReadADC0_SingleEnded(ADC0_SE13) /  4095.0; //Alpha
+                Pot_Value =  (float)ReadADC1_SingleEnded(ADC0_SE4) /  4095.0; //Alpha
                 break;
 
             case POT_BETA:
-                Pot_Value =  (float)ReadADC0_SingleEnded(ADC0_SE23)	/  4095.0; //beta
+                Pot_Value =  (float)ReadADC0_SingleEnded(ADC0_SE4)	/  4095.0; //beta
                 break;
 
             case POT_GAMMA:
-                Pot_Value =  (float)ReadADC0_SingleEnded(ADC0_SE12)	/  4095.0; //Gamma
+                Pot_Value =  (float)ReadADC1_SingleEnded(ADC0_SE5)	/  4095.0; //Gamma
                 break;
         }
 

--- a/MonkeyJam/Sources/drivers/adc16/adc16.c
+++ b/MonkeyJam/Sources/drivers/adc16/adc16.c
@@ -432,18 +432,23 @@ void InitADC_12Bit()
     // the ADC will be inactive.  Channel 31 is just disable function.
     // There really is no channel 31.
     ADC_Config_Alt(ADC0_BASE_PTR, &Master_Adc_Config);  // config ADC
+    ADC_Config_Alt(ADC1_BASE_PTR, &Master_Adc_Config);  // config ADC
     // Calibrate the ADC in the configuration in which it will be used:
     ADC_Cal(ADC0_BASE_PTR);                    // do the calibration
+    ADC_Cal(ADC1_BASE_PTR);                    // do the calibration
+
     // The structure still has the desired configuration.  So restore it.
     // Why restore it?  The calibration makes some adjustments to the
     // configuration of the ADC.  The are now undone:
     // config the ADC again to desired conditions
     ADC_Config_Alt(ADC0_BASE_PTR, &Master_Adc_Config);
+    ADC_Config_Alt(ADC1_BASE_PTR, &Master_Adc_Config);
     // *****************************************************************************
     //      ADC0 using the PDB trigger in ping pong
     // *****************************************************************************
     // use interrupts, single ended mode, and real channel numbers now:
     ADC_Config_Alt(ADC0_BASE_PTR, &Master_Adc_Config);  // config ADC0
+    ADC_Config_Alt(ADC1_BASE_PTR, &Master_Adc_Config);  // config ADC1
 }
 
 
@@ -453,15 +458,15 @@ void InitADC_12Bit()
 void StartADC0_SingleEnded(uint8_t Channel,uint8_t MuxSide)
 {
     if(MuxSide == 0)
-        {
-            //Select The a side of the MUX
-            ADC0_CFG1 &= ~(ADC_CFG2_MUXSEL_MASK);
-        }
+    {
+    	//Select The a side of the MUX
+        ADC0_CFG1 &= ~(ADC_CFG2_MUXSEL_MASK);
+    }
     else
-        {
-            //Select The b side of the MUX
-            ADC0_CFG1 |= (ADC_CFG2_MUXSEL_MASK);
-        }
+    {
+        //Select The b side of the MUX
+        ADC0_CFG1 |= (ADC_CFG2_MUXSEL_MASK);
+    }
 
     ADC0_SC1A  = Channel;
 }
@@ -471,9 +476,36 @@ uint16_t ReadADC0_SingleEnded(uint8_t Channel,uint8_t MuxSide)
     StartADC0_SingleEnded(Channel,MuxSide);
 
     while((ADC0_SC1A & ADC_SC1_COCO_MASK) == 0)
-        {
-            //Wait For Conversion Complete
-        }
+    {
+        //Wait For Conversion Complete
+    }
 
     return ADC0_RA;
+}
+void StartADC1_SingleEnded(uint8_t Channel,uint8_t MuxSide)
+{
+    if(MuxSide == 0)
+    {
+    	//Select The a side of the MUX
+        ADC1_CFG1 &= ~(ADC_CFG2_MUXSEL_MASK);
+    }
+    else
+    {
+        //Select The b side of the MUX
+        ADC1_CFG1 |= (ADC_CFG2_MUXSEL_MASK);
+    }
+
+    ADC1_SC1A  = Channel;
+}
+
+uint16_t ReadADC1_SingleEnded(uint8_t Channel,uint8_t MuxSide)
+{
+    StartADC1_SingleEnded(Channel,MuxSide);
+
+    while((ADC1_SC1A & ADC_SC1_COCO_MASK) == 0)
+    {
+        //Wait For Conversion Complete
+    }
+
+    return ADC1_RA;
 }

--- a/MonkeyJam/Sources/drivers/adc16/adc16.h
+++ b/MonkeyJam/Sources/drivers/adc16/adc16.h
@@ -76,10 +76,13 @@
 
 
 
-uint16_t ReadADC_SingleEnded(uint8_t Channel,uint8_t MuxSide);
+
 
 void InitADC_12Bit();
 
+uint16_t ReadADC0_SingleEnded(uint8_t Channel,uint8_t MuxSide);
+uint16_t ReadADC1_SingleEnded(uint8_t Channel,uint8_t MuxSide);
 void StartADC0_SingleEnded(uint8_t Channel,uint8_t MuxSide);
+void StartADC1_SingleEnded(uint8_t Channel,uint8_t MuxSide);
 
 #endif /* __ADC16_H__ */

--- a/MonkeyJam/Sources/drivers/frdm-k22-def.c
+++ b/MonkeyJam/Sources/drivers/frdm-k22-def.c
@@ -1,0 +1,142 @@
+/****************************************************************************************************/
+
+/**
+Copyright (c) 2011 Freescale Semiconductor
+Freescale Confidential Proprietary
+\file       frdm-k22-def.h.c
+\brief
+\author
+\author
+\version    1.0
+\date       Sep 26, 2011
+*/
+
+#include "frdm-k22-def.h"
+
+
+/*
+Initialize GPIO of TWRK40
+   LEDS as outputs and simple test
+
+SW3 (IRQ0) PTC5
+SW4 (IRQ1) PTC13
+SW5 (RESET) RESET_b
+
+
+
+*/
+
+void frdm_GPIO_init(void)
+{
+    /*
+     PORTC_PCR7 = PCR_OUTPUT_CONFIG;
+     PORTC_PCR8 = PCR_OUTPUT_CONFIG;
+     GPIOC_PDDR |= (1<<8) | (1<<7);
+     */
+#ifdef LED1
+    LED1_PCR = PCR_OUTPUT_CONFIG;
+    LED1_OFF;
+    LED1_OUTPUT_EN;
+#endif
+#ifdef LED2
+    LED2_PCR = PCR_OUTPUT_CONFIG;
+    LED2_OFF;
+    LED2_OUTPUT_EN;
+#endif
+#ifdef LED3
+    LED3_PCR = PCR_OUTPUT_CONFIG;
+    LED3_OFF;
+    LED3_OUTPUT_EN;
+#endif
+#ifdef LED4
+    LED4_PCR = PCR_OUTPUT_CONFIG;
+    LED4_OFF;
+    LED4_OUTPUT_EN;
+#endif
+#ifdef SW1
+    SW1_PCR = PCR_INPUT_CONFIG;
+    SW1_INPUT_EN;
+#endif
+#ifdef SW2
+    SW2_PCR = PCR_INPUT_CONFIG;
+    SW2_INPUT_EN;
+#endif
+}
+
+/*
+ raising(input,aux_mem
+  return 1
+     when input=1 and aux=0
+     aux=input
+*/
+
+char input_rise
+(
+    char    input,
+    char    *mem
+)
+{
+    /*~~~~~~~~~~~~~~~*/
+    /*~~~~~~~~~~~~~~~*/
+    /*~~~~~~~~~~~~~~~*/
+    /*~~~~~~~~~~~~~~~*/
+    /*~~~~~~~~~~~~~~~*/
+    /*~~~~~~~~~~~~~~~*/
+    char    result = 0;
+
+    /*~~~~~~~~~~~~~~~*/
+
+    /*~~~~~~~~~~~~~~~*/
+
+    /*~~~~~~~~~~~~~~~*/
+
+    /*~~~~~~~~~~~~~~~*/
+
+    /*~~~~~~~~~~~~~~~*/
+
+    /*~~~~~~~~~~~~~~~*/
+
+    if(input && !*mem) result = 1;
+
+    *mem = input;
+    return result;
+}
+
+/*
+
+  return 1
+     when input=1 and aux=0
+     aux=input
+*/
+
+char input_fall
+(
+    char    input,
+    char    *mem
+)
+{
+    /*~~~~~~~~~~~~~~~*/
+    /*~~~~~~~~~~~~~~~*/
+    /*~~~~~~~~~~~~~~~*/
+    /*~~~~~~~~~~~~~~~*/
+    /*~~~~~~~~~~~~~~~*/
+    /*~~~~~~~~~~~~~~~*/
+    char    result = 0;
+
+    /*~~~~~~~~~~~~~~~*/
+
+    /*~~~~~~~~~~~~~~~*/
+
+    /*~~~~~~~~~~~~~~~*/
+
+    /*~~~~~~~~~~~~~~~*/
+
+    /*~~~~~~~~~~~~~~~*/
+
+    /*~~~~~~~~~~~~~~~*/
+
+    if(!input && *mem) result = 1;
+
+    *mem = input;
+    return result;
+}

--- a/MonkeyJam/Sources/drivers/frdm-k22-def.h
+++ b/MonkeyJam/Sources/drivers/frdm-k22-def.h
@@ -1,0 +1,141 @@
+/****************************************************************************************************/
+
+/**
+Copyright (c) 2011 Freescale Semiconductor
+\file       frdm-k22-def.h
+\brief
+\author
+\author
+\version    1.0
+\date       Sep 26, 2011
+*/
+
+#include "derivative.h"
+
+#define BIT_MASK(x) (0x1 << x)
+
+// User should only define wich port and the bit
+
+#define LED1_PORT   A   // Greeen LED
+#define LED1_BIT    2
+
+#define LED2_PORT   A   // Red LED
+#define LED2_BIT    1
+
+#define LED3_PORT   D   // Blue LED
+#define LED3_BIT    5
+
+//#undef LED4_PORT   C    //
+//#undef LED4_BIT    8
+
+/*
+SW1  as  SW3 (IRQ0) PTC5
+SW2  SW4 (IRQ1) PTC13
+ SW5 (RESET) RESET_b
+*/
+
+//#undef  SW1_PORT   C
+//#undef  SW1_BIT    1
+//#undef  SW2_PORT   C
+//#undef  SW2_BIT    2
+
+// Compilation time Definitions
+
+#define PCR(PTO, BIT)       PORT##PTO##_PCR##BIT
+#define PDDR(PTO)           GPIO##PTO##_PDDR
+#define PSOR(PORT)          GPIO##PORT##_PSOR
+#define PCOR(PORT)          GPIO##PORT##_PCOR
+#define PTOR(PORT)          GPIO##PORT##_PTOR
+#define PDOR(PORT)          GPIO##PORT##_PDOR
+#define PDIR(PORT)          GPIO##PORT##_PDIR
+
+#define PCR_OUTPUT_CONFIG   (PORT_PCR_MUX(1) | PORT_PCR_DSE_MASK)                   //Pin configured as GPIO
+#define PCR_INPUT_CONFIG    (PORT_PCR_MUX(1) | PORT_PCR_PE_MASK | PORT_PCR_PS_MASK) //Pin configured as GPIO Input with pull up enable
+#ifdef LED1_PORT
+#define LED1
+#define LED1_PCR_OUTPUT(LED1_PORT, LED1_BIT)    PCR(LED1_PORT, LED1_BIT)
+#define LED1_DDR_OUTPUT(LED1_PORT, LED1_BIT)    PDDR(LED1_PORT) |= (1 << LED1_BIT)
+#define LED1_PSOR(LED1_PORT, LED1_BIT)          PSOR(LED1_PORT) |= (1 << LED1_BIT)
+#define LED1_PCOR(LED1_PORT, LED1_BIT)          PCOR(LED1_PORT) |= (1 << LED1_BIT)
+#define LED1_PTOR(LED1_PORT, LED1_BIT)          PTOR(LED1_PORT) |= (1 << LED1_BIT)
+#define LED1_PCR                                LED1_PCR_OUTPUT(LED1_PORT, LED1_BIT)
+#define LED1_OUTPUT_EN                          LED1_DDR_OUTPUT(LED1_PORT, LED1_BIT)
+#define LED1_SET                                LED1_PSOR(LED1_PORT, LED1_BIT)
+#define LED1_CLR                                LED1_PCOR(LED1_PORT, LED1_BIT)
+#define LED1_ON                                 LED1_PCOR(LED1_PORT, LED1_BIT)
+#define LED1_OFF                                LED1_PSOR(LED1_PORT, LED1_BIT)
+#define LED1_TOGGLE                             LED1_PTOR(LED1_PORT, LED1_BIT)
+#endif
+#ifdef LED2_PORT
+#define LED2
+#define LED2_PCR_OUTPUT(LED2_PORT, LED2_BIT)    PCR(LED2_PORT, LED2_BIT)
+#define LED2_DDR_OUTPUT(LED2_PORT, LED2_BIT)    PDDR(LED2_PORT) |= (1 << LED2_BIT)
+#define LED2_PSOR(LED2_PORT, LED2_BIT)          PSOR(LED2_PORT) |= (1 << LED2_BIT)
+#define LED2_PCOR(LED2_PORT, LED2_BIT)          PCOR(LED2_PORT) |= (1 << LED2_BIT)
+#define LED2_PTOR(LED2_PORT, LED2_BIT)          PTOR(LED2_PORT) |= (1 << LED2_BIT)
+#define LED2_PCR                                LED2_PCR_OUTPUT(LED2_PORT, LED2_BIT)
+#define LED2_OUTPUT_EN                          LED2_DDR_OUTPUT(LED2_PORT, LED2_BIT)
+#define LED2_SET                                LED2_PSOR(LED2_PORT, LED2_BIT)
+#define LED2_CLR                                LED2_PCOR(LED2_PORT, LED2_BIT)
+#define LED2_ON                                 LED2_PCOR(LED2_PORT, LED2_BIT)
+#define LED2_OFF                                LED2_PSOR(LED2_PORT, LED2_BIT)
+#define LED2_TOGGLE                             LED2_PTOR(LED2_PORT, LED2_BIT)
+#endif
+
+//#ifdef  LED3_PORT
+
+#define LED3
+#define LED3_PCR_OUTPUT(LED3_PORT, LED3_BIT)    PCR(LED3_PORT, LED3_BIT)
+#define LED3_DDR_OUTPUT(LED3_PORT, LED3_BIT)    PDDR(LED3_PORT) |= (1 << LED3_BIT)
+#define LED3_PSOR(LED3_PORT, LED3_BIT)          PSOR(LED3_PORT) |= (1 << LED3_BIT)
+#define LED3_PCOR(LED3_PORT, LED3_BIT)          PCOR(LED3_PORT) |= (1 << LED3_BIT)
+#define LED3_PTOR(LED3_PORT, LED3_BIT)          PTOR(LED3_PORT) |= (1 << LED3_BIT)
+#define LED3_PCR                                LED3_PCR_OUTPUT(LED3_PORT, LED3_BIT)
+#define LED3_OUTPUT_EN                          LED3_DDR_OUTPUT(LED3_PORT, LED3_BIT)
+#define LED3_CLR                                LED3_PCOR(LED3_PORT, LED3_BIT)
+#define LED3_SET                                LED3_PSOR(LED3_PORT, LED3_BIT)
+#define LED3_ON                                 LED3_PCOR(LED3_PORT, LED3_BIT)
+#define LED3_OFF                                LED3_PSOR(LED3_PORT, LED3_BIT)
+#define LED3_TOGGLE                             LED3_PTOR(LED3_PORT, LED3_BIT)
+
+//#endif
+
+#ifdef LED4_PORT
+#define LED4
+#define LED4_PCR_OUTPUT(LED4_PORT, LED4_BIT)    PCR(LED4_PORT, LED4_BIT)
+#define LED4_DDR_OUTPUT(LED4_PORT, LED4_BIT)    PDDR(LED4_PORT) |= (1 << LED4_BIT)
+#define LED4_PSOR(LED4_PORT, LED4_BIT)          PSOR(LED4_PORT) |= (1 << LED4_BIT)
+#define LED4_PCOR(LED4_PORT, LED4_BIT)          PCOR(LED4_PORT) |= (1 << LED4_BIT)
+#define LED4_PTOR(LED4_PORT, LED4_BIT)          PTOR(LED4_PORT) |= (1 << LED4_BIT)
+#define LED4_PDOR(LED4_PORT, LED4_BIT)          PDOR(LED4_PORT) & (1 << LED4_BIT)
+#define LED4_PCR                                LED4_PCR_OUTPUT(LED4_PORT, LED4_BIT)
+#define LED4_OUTPUT_EN                          LED4_DDR_OUTPUT(LED4_PORT, LED4_BIT)
+#define LED4_CLR                                LED4_PCOR(LED4_PORT, LED4_BIT)      //Led turn with positive
+#define LED4_SET                                LED4_PSOR(LED4_PORT, LED4_BIT)
+#define LED4_OFF                                LED4_PCOR(LED4_PORT, LED4_BIT)      //Led turn with positive
+#define LED4_ON                                 LED4_PSOR(LED4_PORT, LED4_BIT)
+#define LED4_TOGGLE                             LED4_PTOR(LED4_PORT, LED4_BIT)
+#endif
+#ifdef SW1_PORT
+#define SW1
+#define SW1_PCR_INPUT(SW1_PORT, SW1_BIT)    PCR(SW1_PORT, SW1_BIT)
+#define SW1_DDR_INPUT(SW1_PORT, SW1_BIT)    PDDR(SW1_PORT) &= ~(1 << SW1_BIT)
+#define SW1_DIR_INPUT(SW1_PORT, SW1_BIT)    (PDIR(SW1_PORT) & (1 << SW1_BIT))
+#define SW1_PCR                             SW1_PCR_INPUT(SW1_PORT, SW1_BIT)
+#define SW1_INPUT_EN                        SW1_DDR_INPUT(SW1_PORT, SW1_BIT)
+#define SW1_VAL                             SW1_DIR_INPUT(SW1_PORT, SW1_BIT)
+#define SW1_ON                              !SW1_VAL
+#endif
+#ifdef SW2_PORT
+#define SW2
+#define SW2_PCR_INPUT(SW2_PORT, SW2_BIT)    PCR(SW2_PORT, SW2_BIT)
+#define SW2_DDR_INPUT(SW2_PORT, SW2_BIT)    PDDR(SW2_PORT) &= ~(1 << SW2_BIT)
+#define SW2_DIR_INPUT(SW2_PORT, SW2_BIT)    (PDIR(SW2_PORT) & (1 << SW2_BIT))
+#define SW2_PCR                             SW2_PCR_INPUT(SW2_PORT, SW2_BIT)
+#define SW2_INPUT_EN                        SW2_DDR_INPUT(SW2_PORT, SW2_BIT)
+#define SW2_VAL                             SW2_DIR_INPUT(SW2_PORT, SW2_BIT)
+#define SW2_ON                              !SW2_VAL
+#endif
+void    frdm_GPIO_init(void);
+char    input_rise(char input, char *mem);
+char    input_fall(char input, char *mem);

--- a/MonkeyJam/Sources/drivers/sai/sai.c
+++ b/MonkeyJam/Sources/drivers/sai/sai.c
@@ -8,7 +8,7 @@
 #include "../../cpu/arm_cm4.h"
 #include "derivative.h"
 #include "sai.h"
-#include "../frdm-k20-def.h"
+#include "../frdm-k22-def.h"
 #include "../../DSP/MathTables.h"
 #include "../../DSP/AudioProcess.h"
 #include "../IO.h"
@@ -19,9 +19,9 @@
  *	I2S0_TX_FS - 	PTC2 or PTB19  or PTA13
  *	I2S0_RX_BCLK - 	PTC9	or PTC6
  *	I2S0_RX_FS - 	PTC10 or PTC7
- * 	I2S0_RXD0 -	PTC5
+ * 	I2S0_RXD0 -		PTC5
  *	I2S0_RXD1 - 	PTC11
- *	I2S0_TXD0 -	PTC1  or PTA12
+ *	I2S0_TXD0 -		PTC1  or PTA12
  *	I2S0_TXD1 - 	PTC0
  * 	I2S0_MCLK - 	PTC6 or PTC8
  *
@@ -43,30 +43,30 @@ void sai_pinmux_init
     if(port == 0)
         {
             if(setting == 0)                        //using PORTC pins
-                {
+            {
                     PORTC_PCR(3) = PORT_PCR_MUX(6);     //PTC3(ALT6), I2S0_TX_BCLK	-	J37 pin2
                     PORTC_PCR(2) = PORT_PCR_MUX(6);     //PTC2(ALT6), I2S0_TX_FS	-	J51 pin11 or 14
                     PORTC_PCR(9) = PORT_PCR_MUX(4);     //PTC9(ALT4), I2S0_RX_BCLK	-	J44 pin5
-                    PORTC_PCR(10) = PORT_PCR_MUX(4);    //PTC10(ALT4), I2S0_RX_FS	-	J44 pin8
+                    PORTC_PCR(10)= PORT_PCR_MUX(4);     //PTC10(ALT4), I2S0_RX_FS	-	J44 pin8
                     PORTC_PCR(5) = PORT_PCR_MUX(4);     //PTC5(ALT4), I2S0_RXD0	-	J37 pin8
-                  //  PORTC_PCR(11) = PORT_PCR_MUX(4);    //PTC11(ALT4), I2S0_RXD1	-	J44 pin11
+                    PORTC_PCR(11)= PORT_PCR_MUX(4);     //PTC11(ALT4), I2S0_RXD1	-	J44 pin11
                     PORTC_PCR(1) = PORT_PCR_MUX(6);     //PTC1(ALT6), I2S0_TXD0	-	J51 pin5 or 8
-           //         PORTC_PCR(0) = PORT_PCR_MUX(6);     //PTC0(ALT6), I2S0_TXD1	-	J51 pin2
+                    PORTC_PCR(0) = PORT_PCR_MUX(6);     //PTC0(ALT6), I2S0_TXD1	-	J51 pin2
                     PORTC_PCR(6) = PORT_PCR_MUX(6);     //PTC6(ALT6), I2S0_MCLK	-	J37 pin11
                     PORTC_PCR(8) = PORT_PCR_MUX(4);     //PTC6(ALT6), I2S0_MCLK	-	J37 pin11
-                }
+            }
             else if(setting == 1)                   //using PORTA pins
-                {
+            {
                     PORTA_PCR(5) = PORT_PCR_MUX(6);     //PTA5(ALT6), I2S0_TX_BCLK -	J35 pin8
-                    PORTA_PCR(13) = PORT_PCR_MUX(6);    //PTA13(ALT6), I2S0_TX_FS -		J35 pin14
+                    PORTA_PCR(13)= PORT_PCR_MUX(6);     //PTA13(ALT6),I2S0_TX_FS -		J35 pin14
                     PORTC_PCR(6) = PORT_PCR_MUX(4);     //PTC6(ALT4), I2S0_RX_BCLK	-	J37 pin11
                     PORTC_PCR(7) = PORT_PCR_MUX(4);     //PTC7(ALT4), I2S0_RX_FS	-	J37 pin14
                     PORTC_PCR(5) = PORT_PCR_MUX(4);     //PTC5(ALT4), I2S0_RXD0	-
-                    PORTC_PCR(11) = PORT_PCR_MUX(4);    //PTC11(ALT4), I2S0_RXD1 -
-                    PORTA_PCR(12) = PORT_PCR_MUX(6);    //PTA12(ALT6), I2S0_TXD0	-	J35 pin11
+                    PORTC_PCR(11)= PORT_PCR_MUX(4);     //PTC11(ALT4),I2S0_RXD1 -
+                    PORTA_PCR(12)= PORT_PCR_MUX(6);     //PTA12(ALT6),I2S0_TXD0	-	J35 pin11
                     PORTC_PCR(0) = PORT_PCR_MUX(6);     //PTC0(ALT6), I2S0_TXD1 -
                     PORTC_PCR(8) = PORT_PCR_MUX(4);     //PTC8(ALT4), I2S0_MCLK	-	J44 pin2
-                }
+            }
         }
     else if(port == 1)
         {

--- a/MonkeyJam/Sources/main.c
+++ b/MonkeyJam/Sources/main.c
@@ -71,7 +71,7 @@
 
 #include "Derivative.h" /* include peripheral declarations */
 #include "arm_math.h"
-#include "drivers/frdm-K20-def.h"
+#include "drivers/frdm-K22-def.h"
 #include "drivers/mcg/mcg.h"
 #include "drivers/sai/sai.h"
 #include "cpu/arm_cm4.h"


### PR DESCRIPTION
This patch changes the source of AudioIF, IO, ADC and SAI
drivers to work with freedom board K22

Signed-off-by: Denis Shimizu denis.shimizu@freescale.com
Signed-off-by: Rogerio Pimentel rogeriopimentel@hotmail.com
